### PR TITLE
Improve handling when file is matched but empty

### DIFF
--- a/.changeset/swift-clouds-hunt.md
+++ b/.changeset/swift-clouds-hunt.md
@@ -1,0 +1,5 @@
+---
+"@proload/core": patch
+---
+
+Improve handling when matched file is empty

--- a/packages/core/test/index.mjs
+++ b/packages/core/test/index.mjs
@@ -27,6 +27,21 @@ test('missing but mustExist (default)', async () => {
     is(err, 1);
 });
 
+test('empty but not mustExist', async () => {
+    let mdl = await load('test', { cwd: resolve(`fixtures/empty`), mustExist: false });
+    type(mdl, 'undefined')
+});
+
+test('empty but mustExist (default)', async () => {
+    let err = 0;
+    try {
+        let mdl = await load('test', { cwd: resolve(`fixtures/empty`) });
+    } catch (e) {
+        err += 1;
+    }
+    is(err, 1);
+});
+
 test('missing but not mustExist', async () => {
     let mdl = await load('test', { cwd: resolve(`fixtures/missing`), mustExist: false });
     type(mdl, 'undefined')


### PR DESCRIPTION
Closes #8. Empty files now respect the `mustExist` config option.