### PR TITLE
Add resolve export

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -54,6 +54,18 @@ The `default` export of `@proload/core` is an `async` function to load a configu
 load(namespace: string, opts?: LoadOptions);
 ```
 
+## `resolve`
+
+`resolve` is an additional named export of `@proload/core`. It is an `async` function that resolves **but does not load** a configuration file.
+
+- `namespace` is the name of your tool. As an example, `donut` would search for `donut.config.[ext]`.
+- `opts` configure the behavior of `load`. See [Options](https://github.com/natemoo-re/proload/tree/main/packages/core#options).
+
+```ts
+resolve(namespace: string, opts?: ResolveOptions);
+```
+
+
 
 ## Options
 

--- a/packages/core/lib/esm/index.mjs
+++ b/packages/core/lib/esm/index.mjs
@@ -1,5 +1,5 @@
 import escalade from "escalade";
-import { join, dirname, extname, resolve } from "path";
+import { join, dirname, extname, resolve as resolvePath } from "path";
 import deepmerge from "deepmerge";
 
 import { existsSync, readdir, readFile, stat } from "fs";
@@ -81,7 +81,7 @@ async function resolveExtension(namespace, { filePath, extension }) {
   let resolvedPath;
   if (extension.startsWith("./") || extension.startsWith("../")) {
     if (extname(extension) === "") {
-      resolvedPath = resolve(
+      resolvedPath = resolvePath(
         dirname(filePath),
         `${extension}${extname(filePath)}`
       );
@@ -89,7 +89,7 @@ async function resolveExtension(namespace, { filePath, extension }) {
     if (!existsSync(resolvedPath)) resolvedPath = null;
 
     if (!resolvedPath) {
-      resolvedPath = resolve(dirname(filePath), extension);
+      resolvedPath = resolvePath(dirname(filePath), extension);
     }
     if (!existsSync(resolvedPath)) resolvedPath = null;
   }
@@ -174,7 +174,7 @@ export async function resolve(namespace, opts = {}) {
   let filePath;
   if (typeof opts.filePath === "string") {
     const absPath = opts.filePath.startsWith(".")
-      ? resolve(opts.filePath, input)
+      ? resolvePath(opts.filePath, input)
       : opts.filePath;
     if (existsSync(absPath)) {
       filePath = absPath;
@@ -247,7 +247,7 @@ async function load(namespace, opts = {}) {
   let filePath;
   if (typeof opts.filePath === "string") {
     const absPath = opts.filePath.startsWith(".")
-      ? resolve(opts.filePath, input)
+      ? resolvePath(opts.filePath, input)
       : opts.filePath;
     if (existsSync(absPath)) {
       filePath = absPath;

--- a/packages/core/lib/esm/index.mjs
+++ b/packages/core/lib/esm/index.mjs
@@ -157,12 +157,83 @@ async function resolveExtensions(
 /**
  *
  * @param {string} namespace
+ * @param {import('../index').ResolveOptions} opts
+ */
+export async function resolve(namespace, opts = {}) {
+  const accepted = validNames(namespace);
+  const { accept } = opts;
+  const input = opts.cwd || process.cwd();
+  let mustExist = true;
+  if (typeof opts.mustExist !== "undefined") {
+    mustExist = opts.mustExist;
+  }
+  if (typeof opts.merge === "function") {
+    merge = opts.merge;
+  }
+
+  let filePath;
+  if (typeof opts.filePath === "string") {
+    const absPath = opts.filePath.startsWith(".")
+      ? resolve(opts.filePath, input)
+      : opts.filePath;
+    if (existsSync(absPath)) {
+      filePath = absPath;
+    }
+  } else {
+    filePath = await escalade(input, async (dir, names) => {
+      if (accept) {
+        for (const n of names) {
+          if (accept(n, { directory: dir }) === true) return n;
+        }
+      }
+
+      for (const n of accepted) {
+        if (names.includes(n)) return n;
+      }
+
+      if (names.includes("config")) {
+        let d = join(dir, "config");
+        let _,
+          stats = await toStats(d);
+        let entries = [];
+        if (stats.isDirectory()) {
+          entries = await toRead(d);
+          for (const n of accepted) {
+            if (entries.includes(n)) return join("config", n);
+          }
+        }
+      }
+
+      if (names.includes("package.json")) {
+        let file = join(dir, "package.json");
+        let _,
+          contents = await toReadFile(file).then((r) =>
+            JSON.parse(r.toString())
+          );
+        if (contents[namespace]) return "package.json";
+      }
+    });
+  }
+
+  if (mustExist) {
+    assert(
+      !!filePath,
+      `Unable to resolve a ${namespace} configuration`,
+      "ERR_PROLOAD_NOT_FOUND"
+    );
+  } else if (!filePath) {
+    return;
+  }
+  return filePath;
+}
+
+/**
+ *
+ * @param {string} namespace
  * @param {import('../index').LoadOptions} opts
  */
 async function load(namespace, opts = {}) {
-  // if (opts)
-  const accepted = validNames(namespace);
-  const { context, accept } = opts;
+  const { context } = opts;
   const input = opts.cwd || process.cwd();
 
   let mustExist = true;
@@ -229,7 +300,7 @@ async function load(namespace, opts = {}) {
 
   let rawValue = await requireOrImportWithMiddleware(filePath);
   if (filePath.endsWith("package.json")) rawValue = rawValue[namespace];
-  const hasExport = ('default' in rawValue);
+  const hasExport = "default" in rawValue;
   if (!hasExport) {
     if (mustExist) {
       assert(

--- a/packages/core/lib/esm/index.mjs
+++ b/packages/core/lib/esm/index.mjs
@@ -233,7 +233,8 @@ export async function resolve(namespace, opts = {}) {
  * @param {import('../index').LoadOptions} opts
  */
 async function load(namespace, opts = {}) {
-  const { context } = opts;
+  const accepted = validNames(namespace);
+  const { context, accept } = opts;
   const input = opts.cwd || process.cwd();
 
   let mustExist = true;

--- a/packages/core/lib/index.d.ts
+++ b/packages/core/lib/index.d.ts
@@ -9,6 +9,34 @@ export interface Config<T> {
     value: T;
 }
 
+export interface ResolveOptions {
+    /** 
+      * An exact filePath to a configuration file which should be loaded. If passed, this will keep proload from searching
+      * for matching files.
+      *
+      * [Read the `@proload/core` docs](https://github.com/natemoo-re/proload/tree/main/packages/core#filepath)
+      */
+    filePath?: string;
+    /** 
+      * The location from which to begin searching up the directory tree 
+      *
+      * [Read the `@proload/core` docs](https://github.com/natemoo-re/proload/tree/main/packages/core#cwd)
+      */
+    cwd?: string;
+    /** 
+      * If a configuration _must_ be resolved. If `true`, Proload will throw an error when a configuration is not found
+      *
+      * [Read the `@proload/core` docs](https://github.com/natemoo-re/proload/tree/main/packages/core#mustExist)
+      */
+    mustExist?: boolean;
+    /** 
+      * A function to completely customize module resolution
+      *
+      * [Read the `@proload/core` docs](https://github.com/natemoo-re/proload/tree/main/packages/core#accept)
+      */
+    accept?(fileName: string, context: { directory: string }): boolean|void;
+}
+
 export interface LoadOptions<T> {
     /** 
       * An exact filePath to a configuration file which should be loaded. If passed, this will keep proload from searching
@@ -61,6 +89,13 @@ export interface Plugin {
     /** Modify the config file before passing it along */
     transform?(module: any): Promise<any>;
 }
+
+/**
+ * An `async` function which searches for a configuration file
+ *
+ * [Read the `@proload/core` docs](https://github.com/natemoo-re/proload/tree/main/packages/core#resolve)
+ */
+declare async function resolve(namespace: string, opts?: ResolveOptions): Promise<string|undefined>;
 
 interface Load<T extends Record<any, any> = Record<any, any>> {
     /**


### PR DESCRIPTION
Closes #7. Exposes a `resolve` export that does not load a file, just returns the path.