### PR TITLE
Fix: ESM parse errors should be catch-able

### DIFF
--- a/.changeset/cyan-dingos-fly.md
+++ b/.changeset/cyan-dingos-fly.md
@@ -1,0 +1,5 @@
+---
+"@proload/core": patch
+---
+
+Fix: make ESM parse errors catch-able

--- a/fixtures/esm-parse-error/test.config.mjs
+++ b/fixtures/esm-parse-error/test.config.mjs
@@ -1,0 +1,1 @@
+export defau

--- a/packages/core/lib/esm/requireOrImport.mjs
+++ b/packages/core/lib/esm/requireOrImport.mjs
@@ -10,14 +10,19 @@ let require = createRequire(import.meta.url);
 export default async function requireOrImport(filePath, { middleware = [] } = {}) {
     await Promise.all(middleware.map(plugin => plugin.register(filePath)));
 
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
         try {
             let mdl = require(filePath);
             resolve(mdl);
         } catch (e) {
             if (e.code === 'ERR_REQUIRE_ESM') {
                 const fileUrl = pathToFileURL(filePath).toString();
-                return import(fileUrl).then(mdl => resolve(mdl));
+                try {
+                    const mdl = await import(fileUrl);
+                    return resolve(mdl);
+                } catch (e) {
+                    reject(e);
+                }
             };
             reject(e);
         }

--- a/packages/core/test/index.mjs
+++ b/packages/core/test/index.mjs
@@ -17,6 +17,16 @@ test('exact filePath', async () => {
     is(mdl.value.value, 'exact-filePath')
 });
 
+test('ESM parse errors should be catch-able', async () => {
+    let err = 0;
+    try {
+        await load('test', { cwd: resolve(`fixtures/esm-parse-error`) });
+    } catch (e) {
+        err += 1;
+    }
+    is(err, 1);
+});
+
 test('missing but mustExist (default)', async () => {
     let err = 0;
     try {


### PR DESCRIPTION
I discovered that ESM parse errors would throw uncatch-able errors. This PR should map import errors to a Promise rejection!